### PR TITLE
Fix text length in pixels calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,3 @@ The program generates subtitles in the format on instagram, facebook reels/youtu
 - [ ] Add command line inputs using python argument parser
 - [ ] Create variables for text size and font.
 - [ ] Control number of words shown together with a variable
-- [ ] Fix text coming out issue.

--- a/main.py
+++ b/main.py
@@ -48,7 +48,7 @@ class VideoTranscriber:
                 if words[i] == "":
                     i += 1
                     continue
-                length_in_pixels = len(words[i]) * self.char_width
+                length_in_pixels = (len(words[i]) + 1) * self.char_width
                 remaining_pixels = width - length_in_pixels
                 line = words[i] 
                 
@@ -56,7 +56,7 @@ class VideoTranscriber:
                     i += 1 
                     if i >= len(words):
                         break
-                    length_in_pixels = len(words[i]) * self.char_width
+                    length_in_pixels = (len(words[i]) + 1) * self.char_width
                     remaining_pixels -= length_in_pixels
                     if remaining_pixels < 0:
                         continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+opencv-python
+tqdm
+whisper
+moviepy


### PR DESCRIPTION
Calculating the text length in pixels using:

`length_in_pixels = len(words[i]) * self.char_width`

does not take into account the spaces between words.

This results in the length in pixels of the lines to sometimes be larger than the screen width and therefore the text is coming out of the screen.

Instead, we can use: 

`length_in_pixels = (len(words[i]) + 1) * self.char_width`